### PR TITLE
Add flag 'include' to include/exclude specific files

### DIFF
--- a/shaper-cli/src/main/kotlin/dev/icerock/tools/shaper/cli/ConfigOverrider.kt
+++ b/shaper-cli/src/main/kotlin/dev/icerock/tools/shaper/cli/ConfigOverrider.kt
@@ -49,7 +49,7 @@ class ConfigOverrider {
         println("Default: $value (Press enter to skip change)")
         val input = readLine() ?: return value
         val newValue = if (input.isBlank()) value else mapper(input)
-        println("$path = $newValue")
+        println("$path = $newValue\n")
         return newValue
     }
 

--- a/shaper-core/src/main/kotlin/dev/icerock/tools/shaper/core/HandlebarsFactory.kt
+++ b/shaper-core/src/main/kotlin/dev/icerock/tools/shaper/core/HandlebarsFactory.kt
@@ -31,6 +31,9 @@ object HandlebarsFactory {
         handlebars.registerHelper("stu", Helper<String> { context, _ ->
             context.snakeToUpperCamelCase()
         })
+        handlebars.registerHelper("incl", Helper<Boolean> { include, _ ->
+            if (include) "" else Shaper.NOT_INCLUDE
+        })
         return handlebars
     }
 }

--- a/shaper-core/src/main/kotlin/dev/icerock/tools/shaper/core/Shaper.kt
+++ b/shaper-core/src/main/kotlin/dev/icerock/tools/shaper/core/Shaper.kt
@@ -16,8 +16,9 @@ class Shaper(private val templateConfig: TemplateConfig) {
         templateConfig.files.forEach { fileConfig ->
             val allParams = templateConfig.globalParams + fileConfig.templateParams
 
-            val fileNameTemplate = handlebars.compileInline(fileConfig.pathTemplate)
+            val fileNameTemplate = handlebars.compileInline(fileConfig.pathTemplate.replace("\\", "/"))
             val filePath = fileNameTemplate.apply(allParams)
+            if (filePath.contains(NOT_INCLUDE)) return@forEach
 
             val file = File(outputPath, filePath)
             with(file.parentFile) {
@@ -47,5 +48,9 @@ class Shaper(private val templateConfig: TemplateConfig) {
             resultWriter.appendLine()
         }
         return resultWriter.toString()
+    }
+
+    companion object {
+        const val NOT_INCLUDE = "{not_include}"
     }
 }

--- a/shaper-core/src/main/kotlin/dev/icerock/tools/shaper/core/YamlConfigReader.kt
+++ b/shaper-core/src/main/kotlin/dev/icerock/tools/shaper/core/YamlConfigReader.kt
@@ -40,11 +40,9 @@ object YamlConfigReader {
             }
         } else if (filesDirectory != null) {
             val filesDir = File(directory, filesDirectory)
-            val rootPrefix = filesDir.path + "/"
-
             filesDir.walkTopDown().filterNot { it.isDirectory }.map {
                 TemplateConfig.FileConfig(
-                    pathTemplate = it.path.removeSuffix(".hbs").removePrefix(rootPrefix),
+                    pathTemplate = it.relativeTo(filesDir).path.removeSuffix(".hbs"),
                     contentTemplateName = it.path,
                     templateParams = emptyMap()
                 )


### PR DESCRIPTION
It's a simple implementation to support including/excluding files in yaml file based on global params asked during shaper-cli execution.

Example:
```
globalParams:
  packageName: dev.icerock.app
  feature: auth
  screen: Auth
  addFragment: false

files:
  - pathTemplate: 'android-app/src/main/java/{{dts packageName}}/feature/{{dts feature}}/{{dts screen}}Fragment.kt'
    contentTemplateName: fragment/fragment.kt.hbs
    include: '{{addFragment}}'
  - pathTemplate: 'android-app/src/main/res/layout/fragment_{{cts screen}}.xml'
    contentTemplateName: fragment/layout.xml.hbs
    include: false
```